### PR TITLE
Feature/create one class

### DIFF
--- a/src/blueprints/class_blueprint.py
+++ b/src/blueprints/class_blueprint.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, request
 from bson.json_util import dumps
 from marshmallow import EXCLUDE
-from pymongo.errors import PyMongoError
+from pymongo.errors import PyMongoError, DuplicateKeyError
+from marshmallow import ValidationError
 from datetime import datetime
 from flasgger import swag_from
 
@@ -71,6 +72,28 @@ def get_all_classes():
     resultList = list(result)
 
     return dumps(resultList)
+
+
+@class_blueprint.route("", methods=["POST"])
+def create_class():
+    try:
+        username = request.user.get("Username")
+        new_event = event_schema.load(request.json)
+        new_event["created_by"] = username
+        new_event["updated_at"] = datetime.now().strftime("%d/%m/%Y %H:%M")
+        
+        result = events.insert_one(new_event)
+        return dumps(result.inserted_id)
+    
+    except DuplicateKeyError as err:
+        return {"message": err.details["errmsg"]}, 400
+
+    except ValidationError as err:
+        return {"message": err.messages}, 400
+
+    except Exception as ex:
+        print(ex)
+        return {"message": str(ex)}, 500
 
 
 @class_blueprint.route("many", methods=["POST"])

--- a/src/blueprints/class_blueprint.py
+++ b/src/blueprints/class_blueprint.py
@@ -192,6 +192,8 @@ def update_preferences(subject_code, class_code):
 
     try:
         preferences_schema_load = preferences_schema.load(request.json)
+        building_id = preferences_schema_load['building_id']
+        preferences_schema_load['building_id'] = ObjectId(building_id)
         has_to_be_allocated = request.json["has_to_be_allocated"]
 
         result = events.update_many(

--- a/src/blueprints/class_blueprint.py
+++ b/src/blueprints/class_blueprint.py
@@ -5,6 +5,7 @@ from pymongo.errors import PyMongoError, DuplicateKeyError
 from marshmallow import ValidationError
 from datetime import datetime
 from flasgger import swag_from
+from bson.objectid import ObjectId
 
 from src.common.database import database
 from src.common.crawler import get_jupiter_class_infos
@@ -80,9 +81,10 @@ def create_class():
         inserted = []
         username = request.user.get("Username")
         events_list = request.json
-        print("Dados: ", request.json)
         for event in events_list:
             new_event = event_schema.load(event)
+            building_id = new_event["preferences"]["building_id"]
+            new_event["preferences"]["building_id"] = ObjectId(building_id)
             new_event["created_by"] = username
             new_event["updated_at"] = datetime.now().strftime("%d/%m/%Y %H:%M")
         
@@ -247,6 +249,7 @@ def edit_class(subject_code, class_code):
                 "subject_code": subject_code,
                 "class_code": class_code,
                 "week_day": event["week_day_id"],
+                "start_time": event["start_time_id"],
                 "created_by": username,
             }
 
@@ -257,7 +260,7 @@ def edit_class(subject_code, class_code):
                         "week_day": event["week_day"],
                         "start_time": event["start_time"],
                         "end_time": event["end_time"],
-                        "professor": event["professor"],
+                        "professors": event["professors"],
                         "subscribers": event["subscribers"],
                         "updated_at": datetime.now().strftime("%d/%m/%Y %H:%M"),
                     }
@@ -269,6 +272,7 @@ def edit_class(subject_code, class_code):
 
     except Exception as ex:
         print(ex)
+        print("Eita")
         return {"message": str(ex)}, 500
 
 

--- a/src/blueprints/class_blueprint.py
+++ b/src/blueprints/class_blueprint.py
@@ -55,7 +55,7 @@ def get_all_classes():
                     "class_code": {"$first": "$class_code"},
                     "subject_code": {"$first": "$subject_code"},
                     "subject_name": {"$first": "$subject_name"},
-                    "professors": {"$push": "$professor"},
+                    "professors": {"$first": "$professors"},
                     "start_period": {"$first": "$start_period"},
                     "end_period": {"$first": "$end_period"},
                     "start_time": {"$push": "$start_time"},
@@ -77,18 +77,26 @@ def get_all_classes():
 @class_blueprint.route("", methods=["POST"])
 def create_class():
     try:
+        inserted = []
         username = request.user.get("Username")
-        new_event = event_schema.load(request.json)
-        new_event["created_by"] = username
-        new_event["updated_at"] = datetime.now().strftime("%d/%m/%Y %H:%M")
+        events_list = request.json
+        print("Dados: ", request.json)
+        for event in events_list:
+            new_event = event_schema.load(event)
+            new_event["created_by"] = username
+            new_event["updated_at"] = datetime.now().strftime("%d/%m/%Y %H:%M")
         
-        result = events.insert_one(new_event)
-        return dumps(result.inserted_id)
+            result = events.insert_one(new_event)
+            inserted.append(result.inserted_id)
+
+        return dumps({"inserted" : inserted })
     
     except DuplicateKeyError as err:
+        print(err)
         return {"message": err.details["errmsg"]}, 400
 
     except ValidationError as err:
+        print(err)
         return {"message": err.messages}, 400
 
     except Exception as ex:

--- a/src/schemas/class_schema.py
+++ b/src/schemas/class_schema.py
@@ -11,7 +11,7 @@ class ArraySumField(fields.Field):
 
 
 class PreferencesSchema(Schema):
-    building = fields.Str(required=True)
+    building_id = fields.Str(required=True)
     air_conditioning = fields.Bool()
     projector = fields.Bool()
     accessibility = fields.Bool()

--- a/src/schemas/event_schema.py
+++ b/src/schemas/event_schema.py
@@ -8,7 +8,7 @@ class EventSchema(Schema):
   class_code = fields.Str()
   subject_code = fields.Str()
   subject_name = fields.Str()
-  professor = fields.Str()
+  professors = fields.List(fields.Str())
   start_period = fields.Str()
   end_period = fields.Str()
   start_time = fields.Str()


### PR DESCRIPTION
**Description:**

- Added "POST" route for single class creation
- Change events Schema, now "professor" string field is "professors" and is a string vector field
- Change class Schema, now "building" is "building_id" that represents an entity of building collections
- Change  classes "GET" route, now the way that professors are join is adapted for a vector and not more for single strings
- Change classes "PATCH" route, now the primary key for search query have a new field "start_time" for multiple events in the same day

**Warning:**

- Crawler isn't working as expected anymore, if you use the  professor search filter in a datatable with data from crawler this may break the page, this happens because the professor name field is null (mongoDB search for "professors" vector field and not more for the old "professor" string field) 

**Testing:**

- Class CRUD with frontend : OK
- Class single creation with frontend: OK
- Class edit class with frontend: OK
- Class delete class with frontend: OK
- Class edit preferences with frontend: OK